### PR TITLE
Added OS-dependent use of pkg-config for finding ImageMagick on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,13 @@ set(SRC_NIN10KITGUI
 
 find_package(wxWidgets REQUIRED core base)
 include(${wxWidgets_USE_FILE})
-find_package(ImageMagick COMPONENTS Magick++ MagickWand MagickCore REQUIRED)
+
+if(APPLE)
+    message(STATUS "The platform appears to be macOS, so using pkg-config to find ImageMagick.")
+    pkg_check_modules(ImageMagick Magick++ MagickWand MagickCore)
+else()
+    find_package(ImageMagick COMPONENTS Magick++ MagickWand MagickCore REQUIRED)
+endif(APPLE)
 
 include_directories(${nin10kit_SOURCE_DIR}/shared)
 include_directories(${ImageMagick_INCLUDE_DIRS})


### PR DESCRIPTION
The commit involves making CMake find ImageMagick using pkgconfig instead of find_package due to the latter not functioning properly on macOS. As requested, the change uses the APPLE variable which is set to true on OSX and other Apple devices only, so this should have no effect on other OSes.