### PR TITLE
Add direct export mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(CMAKE_SKIP_RPATH TRUE)
 set(SRC_SHARED
     shared/3ds-exporter.cpp
     shared/ds-exporter.cpp
+    shared/direct-exporter.cpp
     shared/gba-exporter.cpp
     shared/cmd-line-parser-helper.cpp
     shared/color.cpp
@@ -85,6 +86,7 @@ set(SRC_SHARED
     shared/image16.cpp
     shared/image32.cpp
     shared/image8.cpp
+    shared/imagedirect.cpp
     shared/implementationfile.cpp
     shared/logger.cpp
     shared/lut-exporter.cpp

--- a/shared/direct-exporter.cpp
+++ b/shared/direct-exporter.cpp
@@ -1,0 +1,63 @@
+#include <memory>
+#include <vector>
+#include <Magick++.h>
+
+#include "export_params.hpp"
+#include "imagedirect.hpp"
+
+struct ImageInfo
+{
+    Magick::Image image;
+    std::string name;
+    bool hasPalette;
+    size_t nrOfColors;
+};
+
+void DoDirectExport(const std::vector<std::pair<Magick::Image, std::string>>& images)
+{
+    if (images.size() > 0)
+    {
+        // check how many colors the images have and if they have a palette
+        std::vector<ImageInfo> info16;
+        std::vector<ImageInfo> info256;
+        std::vector<ImageInfo> infoRGB;
+        for (const auto &image : images)
+        {
+            ImageInfo info = {image.first, image.second, false, 0};
+            info.hasPalette = image.first.classType() == MagickCore::ClassType::PseudoClass;
+            info.nrOfColors = info.hasPalette ? image.first.colorMapSize() : 0;
+            if (info.hasPalette && info.nrOfColors <= 16)
+            {
+                info16.push_back(info);
+            }
+            else if (info.hasPalette && info.nrOfColors <= 256)
+            {
+                info256.push_back(info);
+            }
+            else
+            {
+                infoRGB.push_back(info);
+            }
+        }
+        // TODO: Find all images with common palettes and put them into one scene.
+        //       Use export_params.symbol_base_name
+        for (const ImageInfo & info : info16)
+        {
+            auto simg = std::make_shared<ImageDirect>(info.image, info.name);
+            header.Add(simg);
+            implementation.Add(simg);
+        }
+        for (const auto &info : info256)
+        {
+            auto simg = std::make_shared<ImageDirect>(info.image, info.name);
+            header.Add(simg);
+            implementation.Add(simg);
+        }
+        for (const auto &info : infoRGB)
+        {
+            auto simg = std::make_shared<ImageDirect>(info.image, info.name);
+            header.Add(simg);
+            implementation.Add(simg);
+        }
+    }
+}

--- a/shared/exportfile.cpp
+++ b/shared/exportfile.cpp
@@ -92,7 +92,7 @@ void ExportFile::AddLutInfo(const LutSpecification& spec)
     luts.push_back(spec);
 }
 
-void ExportFile::Add(std::shared_ptr<Exportable>& image)
+void ExportFile::Add(std::shared_ptr<Exportable> image)
 {
     exportables.push_back(image);
 }

--- a/shared/exportfile.hpp
+++ b/shared/exportfile.hpp
@@ -25,7 +25,7 @@ class ExportFile
         void AddLine(const std::string& line);
         void AddImageInfo(const std::string& filename, int scene, int width, int height, bool frame);
         void AddLutInfo(const LutSpecification& spec);
-        void Add(std::shared_ptr<Exportable>& image);
+        void Add(std::shared_ptr<Exportable> image);
 
         void Clear();
 

--- a/shared/imagedirect.cpp
+++ b/shared/imagedirect.cpp
@@ -1,0 +1,141 @@
+#include "imagedirect.hpp"
+
+#include "export_params.hpp"
+#include "fileutils.hpp"
+#include "logger.hpp"
+#include "shared.hpp"
+
+#include <cstdio>
+
+std::shared_ptr<Palette> GetImagePalette(const Magick::Image &image, const std::string &name)
+{
+    std::vector<Color16> colors;
+    colors.resize(image.colorMapSize());
+    if (image.colorMapSize() <= 256)
+    {
+        for (size_t i = 0; i < image.colorMapSize(); ++i)
+        {
+            Magick::Color mc = image.colorMap(i);
+            unsigned char r = MagickCore::ScaleQuantumToChar(mc.redQuantum());
+            unsigned char g = MagickCore::ScaleQuantumToChar(mc.greenQuantum());
+            unsigned char b = MagickCore::ScaleQuantumToChar(mc.blueQuantum());
+            unsigned char a = MagickCore::ScaleQuantumToChar(mc.alphaQuantum());
+            colors[i] = Color16(r, g, b, a);
+        }
+        return std::make_shared<Palette>(colors, name);
+    }
+    return std::shared_ptr<Palette>();
+}
+
+ImageDirect::ImageDirect(const Magick::Image &image, const std::string& name, std::shared_ptr<Palette> globalPalette) 
+    : Image(image.columns(), image.rows(), name)
+    , m_imageTypeString("const unsigned short")
+    , m_nrOfPixels(image.columns() * image.rows())
+    , m_palette(globalPalette)
+{
+    // check if paletted or direct color
+    if (image.classType() == MagickCore::ClassType::PseudoClass)
+    {
+        // paletted. check if we have one, or get it from the image
+        if (!m_palette)
+        {
+            m_palette = GetImagePalette(image, name);
+        }
+        // convert pixel data
+        if (m_palette->Size() <= 16)
+        {
+            m_nrOfuint16Pixels = m_nrOfPixels / 4;
+            if (width & 3)
+            {
+                WarnLog("Image: %s width is not a multiple of 4. Found (%d %d). Image data can't be written to the screen with DMA.", name.c_str(), width, height);
+            }
+            // reserve data half the number of pixels, we fit 2*4bpp pixels into one byte
+            m_data.resize(m_nrOfPixels / 2);
+            const Magick::PixelPacket *pixelData = image.getConstPixels(0, 0, width, height);
+            for (unsigned int i = 0; i < (m_nrOfPixels / 2); ++i)
+            {
+                uint8_t p0 = pixelData[i*2].blue & 0x0F;
+                uint8_t p1 = pixelData[i*2+1].blue & 0x0F;
+                m_data[i] = (p1 << 4) | p0;
+            }
+        }
+        else if (m_palette->Size() <= 256)
+        {
+            m_nrOfuint16Pixels = m_nrOfPixels / 2;
+            if (width & 1)
+            {
+                WarnLog("Image: %s width is not a multiple of 2. Found (%d %d). Image data can't be written to the screen with DMA.", name.c_str(), width, height);
+            }
+            // reserve data = number of pixels
+            m_data.resize(m_nrOfPixels);
+            const Magick::PixelPacket *pixelData = image.getConstPixels(0, 0, width, height);
+            for (unsigned int i = 0; i < (m_nrOfPixels); ++i)
+            {
+                m_data[i] = pixelData[i].blue & 0xFF;
+            }
+        }
+    }
+    // we have to convert everything above 8bit, because ImageMagick is oh so convenient
+    // and hides the image data from us. we just get 16bit color channel data that we have to reassemble again...
+    else
+    {
+        m_nrOfuint16Pixels = m_nrOfPixels;
+        // we convert the image to 16bit. check if to X1R5G5B5 or A1R5G5B5
+        const bool useAlpha = image.matte() && params.device != "GBA";
+        // reserve data twice the number of pixels
+        m_data.resize(m_nrOfPixels * 2);
+        unsigned short * pixels = reinterpret_cast<unsigned short*>(m_data.data());
+        const Magick::PixelPacket *pixelData = image.getConstPixels(0, 0, width, height);
+        for (unsigned int i = 0; i < (m_nrOfPixels); ++i)
+        {
+            auto ic = pixelData[i];
+            unsigned char r = MagickCore::ScaleQuantumToChar(ic.red);
+            unsigned char g = MagickCore::ScaleQuantumToChar(ic.green);
+            unsigned char b = MagickCore::ScaleQuantumToChar(ic.blue);
+            unsigned char a = MagickCore::ScaleQuantumToChar(ic.opacity);
+            auto c16 = Color16(r, g, b, a);
+            pixels[i] = useAlpha ? c16.ToDSShort() : c16.ToGBAShort();
+        }
+    }
+}
+
+std::string ImageDirect::GetImageType() const
+{
+    return m_imageTypeString + "*";
+}
+
+bool ImageDirect::HasPalette() const
+{
+    return m_palette ? m_palette->Size() > 0 : false;
+}
+
+void ImageDirect::WriteData(std::ostream &file) const
+{
+    // Sole owner of palette
+    if (m_palette)
+    {
+        m_palette->WriteData(file);
+    }
+    WriteShortArray(file, name, "", m_data, 16);
+    WriteNewLine(file);
+}
+
+void ImageDirect::WriteCommonExport(std::ostream &file) const
+{
+    WriteDefine(file, name, "_SIZE", m_data.size());
+    WriteDefine(file, name, "_LENGTH", m_nrOfuint16Pixels);
+    WriteDefine(file, name, "_WIDTH", width);
+    WriteDefine(file, name, "_HEIGHT", height);
+}
+
+void ImageDirect::WriteExport(std::ostream &file) const
+{
+    // Sole owner of palette
+    if (m_palette)
+    {
+        m_palette->WriteExport(file);
+    }
+    WriteExtern(file, m_imageTypeString, name, "", m_nrOfuint16Pixels);
+    WriteCommonExport(file);
+    WriteNewLine(file);
+}

--- a/shared/imagedirect.hpp
+++ b/shared/imagedirect.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <Magick++.h>
+#include <memory>
+#include <vector>
+
+#include "color.hpp"
+#include "image.hpp"
+#include "scene.hpp"
+#include "palette.hpp"
+
+// Represents a single direct-through image.
+// The image will be exported without color conversion if possible. 
+class ImageDirect : public Image
+{
+    public:
+        ImageDirect(const Magick::Image& image, const std::string& name, std::shared_ptr<Palette> globalPalette = nullptr);
+        virtual void WriteData(std::ostream& file) const override;
+        virtual void WriteExport(std::ostream& file) const override;
+        virtual void WriteCommonExport(std::ostream& file) const override;
+        virtual std::string GetImageType() const override;
+        virtual bool HasPalette() const override;
+
+    private:
+        std::string m_imageTypeString;
+        unsigned int m_nrOfPixels = 0;
+        unsigned int m_nrOfuint16Pixels = 0;
+        std::shared_ptr<Palette> m_palette;
+        std::vector<unsigned char> m_data;
+};
+
+// Represents a set of direct-through images.
+// The images will be exported without color conversion if possible. 
+/*class ImageDirectScene : public Scene
+{
+    public:
+        ImageDirectScene(const std::vector<Magick::Image>& images, const std::string& name, std::shared_ptr<Palette> globalPalette = nullptr);
+        const ImageDirect& GetImage(int index) const;
+        virtual void WriteData(std::ostream& file) const override;
+        virtual void WriteExport(std::ostream& file) const override;
+        std::shared_ptr<Palette> GetPalette() const;
+        
+    private:
+        std::shared_ptr<Palette> m_palette;
+};*/


### PR DESCRIPTION
This is a serving suggestion for a "direct" export mode. 4bpp and 8bpp data will be directly output. All direct/true color data will be converted to X1R5G5B5 (GBA) / A1R5G5B5 (xDS). This not really what one would expect, but raw image data does not seem to be available in ImageMagick (at least I could by the life of me not figure out how to get it...).
What is missing? One could directly output 3DS image formats if device==3DS. Also transparent color and some other switches could be supported.
Need to sleep now...